### PR TITLE
6 updates

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,6 +36,7 @@ jobs:
           - test_no_running_tasks_
           - test_rollback_
           - test_options_
+          - test_CLEANUP_IMAGES_
           - test_login_
     steps:
       - name: Checkout Code

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -43,6 +43,7 @@ jobs:
           - test_no_running_tasks_
           - test_rollback_
           - test_options_
+          - test_CLEANUP_IMAGES_
           - test_login_
     steps:
       - name: Checkout Code

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -38,6 +38,7 @@ jobs:
           - test_no_running_tasks_
           - test_rollback_
           - test_options_
+          - test_CLEANUP_IMAGES_
           - test_login_
     steps:
       - name: Checkout Code

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can configure the most behaviors of *Gantry* via environment variables.
 | Environment Variable  | Default | Description |
 |-----------------------|---------|-------------|
 | GANTRY_CLEANUP_IMAGES           | true  | Set to `true` to clean up the updated images. Set to `false` to disable the cleanup. Before cleaning up, *Gantry* will try to remove any *exited* and *dead* containers that are using the images. |
-| GANTRY_NOTIFICATION_APPRISE_URL |       | Enable notifications on service update with [apprise](https://github.com/djmaze/apprise-microservice). This must point to the notification endpoint (e.g. `http://apprise:8000/notify`) |
+| GANTRY_NOTIFICATION_APPRISE_URL |       | Enable notifications on service update with [apprise](https://github.com/caronc/apprise-api). This must point to the notification endpoint (e.g. `http://apprise:8000/notify`) |
 | GANTRY_NOTIFICATION_TITLE       |       | Add an additional message to the notification title. |
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can configure the most behaviors of *Gantry* via environment variables.
 | Environment Variable  | Default | Description |
 |-----------------------|---------|-------------|
 | GANTRY_CLEANUP_IMAGES           | true  | Set to `true` to clean up the updated images. Set to `false` to disable the cleanup. Before cleaning up, *Gantry* will try to remove any *exited* and *dead* containers that are using the images. |
+| GANTRY_CLEANUP_IMAGES_OPTIONS   |       | [Options](https://docs.docker.com/engine/reference/commandline/service_create/#options) added to the `docker service create` command to create a global job for images removal, e.g. adding a label. |
 | GANTRY_NOTIFICATION_APPRISE_URL |       | Enable notifications on service update with [apprise](https://github.com/caronc/apprise-api). This must point to the notification endpoint (e.g. `http://apprise:8000/notify`) |
 | GANTRY_NOTIFICATION_TITLE       |       | Add an additional message to the notification title. |
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gantry
+# Gantry - Docker service updater
 
 [*Gantry*](https://github.com/shizunge/gantry) is a tool to update docker swarm services, [enhanced Shepherd](docs/migration.md).
 
@@ -80,7 +80,7 @@ You can configure the most behaviors of *Gantry* via environment variables.
 | Environment Variable  | Default | Description |
 |-----------------------|---------|-------------|
 | GANTRY_CLEANUP_IMAGES           | true  | Set to `true` to clean up the updated images. Set to `false` to disable the cleanup. Before cleaning up, *Gantry* will try to remove any *exited* and *dead* containers that are using the images. |
-| GANTRY_CLEANUP_IMAGES_OPTIONS   |       | [Options](https://docs.docker.com/engine/reference/commandline/service_create/#options) added to the `docker service create` command to create a global job for images removal, e.g. adding a label. |
+| GANTRY_CLEANUP_IMAGES_OPTIONS   |       | [Options](https://docs.docker.com/engine/reference/commandline/service_create/#options) added to the `docker service create` command to create a global job for images removal. You can use this to add a label to the service of the containers. |
 | GANTRY_NOTIFICATION_APPRISE_URL |       | Enable notifications on service update with [apprise](https://github.com/caronc/apprise-api). This must point to the notification endpoint (e.g. `http://apprise:8000/notify`) |
 | GANTRY_NOTIFICATION_TITLE       |       | Add an additional message to the notification title. |
 

--- a/src/docker_hub_rate.sh
+++ b/src/docker_hub_rate.sh
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-docker_hub_rate_token() {
+_docker_hub_rate_token() {
   local IMAGE="${1:-ratelimitpreview/test}"
   local TOKEN_URL="https://auth.docker.io/token?service=registry.docker.io&scope=repository:${IMAGE}:pull"
   if curl --version 1>/dev/null 2>&1; then
@@ -25,7 +25,7 @@ docker_hub_rate_token() {
   wget -qO- "${TOKEN_URL}"
 }
 
-docker_hub_rate_read_rate() {
+_docker_hub_rate_read_rate() {
   local IMAGE="${1:-ratelimitpreview/test}"
   local TOKEN="${2}"
   [ -z "${TOKEN}" ] && echo "[GET TOKEN ERROR]" && return 1
@@ -43,13 +43,13 @@ docker_hub_rate_read_rate() {
 docker_hub_rate() {
   local IMAGE="${1:-ratelimitpreview/test}"
   local RESPONSE=
-  if ! RESPONSE=$(docker_hub_rate_token "${IMAGE}"); then
+  if ! RESPONSE=$(_docker_hub_rate_token "${IMAGE}"); then
     echo "[GET TOKEN RESPONSE ERROR]"
     return 1
   fi
   local TOKEN=
   TOKEN=$(echo "${RESPONSE}" | sed 's/.*"token":"\([^"]*\).*/\1/')
-  if ! RESPONSE=$(docker_hub_rate_read_rate "${IMAGE}" "${TOKEN}"); then
+  if ! RESPONSE=$(_docker_hub_rate_read_rate "${IMAGE}" "${TOKEN}"); then
     if echo "${RESPONSE}" | grep -q "Too Many Requests" ; then
       echo "0"
       return 0

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -50,26 +50,37 @@ skip_current_node() {
   return 1
 }
 
-exec_pre_run_cmd() {
-  local CMD RT LOG
-  CMD=${GANTRY_PRE_RUN_CMD:-""}
+exec_cmd() {
+  local TAG="${1}"; shift;
+  local CMD="${*}"
+  local OLD_LOG_SCOPE="${LOG_SCOPE}"
+  export LOG_SCOPE="${OLD_LOG_SCOPE} ${TAG}"
   [ -z "${CMD}" ] && return 0
-  log INFO "Run pre-run command: ${CMD}"
-  LOG=$(eval "${CMD}")
-  RT=$?
-  echo "${LOG}" | log_lines INFO
-  log INFO "Finish pre-run command. Return value ${RT}."
+  local LOG=
+  local RT=0
+  log INFO "Run ${TAG} command: ${CMD}"
+  if LOG=$(eval "${CMD}"); then
+    echo "${LOG}" | log_lines INFO
+  else
+    RT=$?
+    echo "${LOG}" | log_lines WARN
+    log WARN "${TAG} command returned a non-zero value ${RT}."
+  fi
+  log INFO "Finish ${TAG} command."
+  export LOG_SCOPE="${OLD_LOG_SCOPE}"
+  return "${RT}"
+}
+
+exec_pre_run_cmd() {
+  local CMD="${GANTRY_PRE_RUN_CMD:-""}"
+  [ -z "${CMD}" ] && return 0
+  exec_cmd "pre-run" "${CMD}"
 }
 
 exec_post_run_cmd() {
-  local CMD RT LOG
-  CMD=${GANTRY_POST_RUN_CMD:-""}
+  local CMD="${GANTRY_POST_RUN_CMD:-""}"
   [ -z "${CMD}" ] && return 0
-  log INFO "Run post-run command: ${CMD}"
-  LOG=$(eval "${CMD}")
-  RT=$?
-  echo "${LOG}" | log_lines INFO
-  log INFO "Finish post-run command. Return value ${RT}."
+  exec_cmd "post-run" "${CMD}"
 }
 
 exec_remove_images() {

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -50,37 +50,16 @@ skip_current_node() {
   return 1
 }
 
-exec_cmd() {
-  local TAG="${1}"; shift;
-  local CMD="${*}"
-  local OLD_LOG_SCOPE="${LOG_SCOPE}"
-  export LOG_SCOPE="${OLD_LOG_SCOPE} ${TAG}"
-  [ -z "${CMD}" ] && return 0
-  local LOG=
-  local RT=0
-  log INFO "Run ${TAG} command: ${CMD}"
-  if LOG=$(eval "${CMD}"); then
-    echo "${LOG}" | log_lines INFO
-  else
-    RT=$?
-    echo "${LOG}" | log_lines WARN
-    log WARN "${TAG} command returned a non-zero value ${RT}."
-  fi
-  log INFO "Finish ${TAG} command."
-  export LOG_SCOPE="${OLD_LOG_SCOPE}"
-  return "${RT}"
-}
-
 exec_pre_run_cmd() {
   local CMD="${GANTRY_PRE_RUN_CMD:-""}"
   [ -z "${CMD}" ] && return 0
-  exec_cmd "pre-run" "${CMD}"
+  eval_cmd "pre-run" "${CMD}"
 }
 
 exec_post_run_cmd() {
   local CMD="${GANTRY_POST_RUN_CMD:-""}"
   [ -z "${CMD}" ] && return 0
-  exec_cmd "post-run" "${CMD}"
+  eval_cmd "post-run" "${CMD}"
 }
 
 exec_remove_images() {

--- a/src/lib-gantry.sh
+++ b/src/lib-gantry.sh
@@ -84,12 +84,13 @@ authenticate_to_registries() {
 }
 
 send_notification() {
-  local TITLE="${1}"
-  local BODY="${2}"
+  local TYPE="${1}"
+  local TITLE="${2}"
+  local BODY="${3}"
   if ! type notify_summary >/dev/null 2>&1; then
     return 0
   fi
-  notify_summary "${TITLE}" "${BODY}"
+  notify_summary "${TYPE}" "${TITLE}" "${BODY}"
 }
 
 add_image_to_remove() {
@@ -228,9 +229,11 @@ report_services() {
   local UPDATED_NUM FAILED_NUM TITLE BODY
   UPDATED_NUM=$(get_number_of_elements "${STATIC_VAR_SERVICES_UPDATED}")
   FAILED_NUM=$(get_number_of_elements "${STATIC_VAR_SERVICES_UPDATE_FAILED}")
+  local TYPE="success"
+  [ "${FAILED_NUM}" -ne "0" ] && TYPE="failure"
   TITLE="[gantry] ${UPDATED_NUM} services updated ${FAILED_NUM} failed"
   BODY=$(echo -e "${UPDATED_MSG}\n${FAILED_MSG}")
-  send_notification "${TITLE}" "${BODY}"
+  send_notification "${TYPE}" "${TITLE}" "${BODY}"
 }
 
 in_list() {

--- a/src/notification.sh
+++ b/src/notification.sh
@@ -15,20 +15,27 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-notify_via_apprise() {
+_notify_via_apprise() {
   local URL="${GANTRY_NOTIFICATION_APPRISE_URL:-""}"
-  local TITLE="${1}"
-  local BODY="${2}"
+  local TYPE="${1}"
+  local TITLE="${2}"
+  local BODY="${3}"
   if [ -z "${URL}" ]; then
     return 0
   fi
-  curl -X POST -H "Content-Type: application/json" --data "{\"title\": \"${TITLE}\", \"body\": \"${BODY}\"}" "${URL}"
+  # info, success, warning, failure
+  if [ "${TYPE}" != "info" ] && [ "${TYPE}" != "success" ] && [ "${TYPE}" != "warning" ] && [ "${TYPE}" != "failure" ]; then
+    TYPE="info"
+  fi
+  [ -z "${BODY}" ] && BODY="${TITLE}"
+  curl -X POST -H "Content-Type: application/json" --data "{\"title\": \"${TITLE}\", \"body\": \"${BODY}\", \"type\": \"${TYPE}\"}" "${URL}"
 }
 
 notify_summary() {
   local CUSTOMIZED_TITLE="${GANTRY_NOTIFICATION_TITLE:-""}"
-  local TITLE="${1}"
-  local BODY="${2}"
+  local TYPE="${1}"
+  local TITLE="${2}"
+  local BODY="${3}"
   [ -n "${CUSTOMIZED_TITLE}" ] && TITLE="${TITLE} ${CUSTOMIZED_TITLE}"
-  notify_via_apprise "${TITLE}" "${BODY}"
+  _notify_via_apprise "${TYPE}" "${TITLE}" "${BODY}"
 }

--- a/tests/lib-gantry-test.sh
+++ b/tests/lib-gantry-test.sh
@@ -53,14 +53,17 @@ initialize_test() {
 
 finalize_test() {
   local TEST_NAME=${1}
-  local TSET_STATUS="OK"
+  local RED='\033[0;31m'
+  local GREEN='\033[0;32m'
+  local NO_COLOR='\033[0m'
+  local TSET_STATUS="${GREEN}OK${NO_COLOR}"
   local RETURN_VALUE=0
   if [ "${STATIC_VAR_THIS_TEST_ERRORS}" -ne 0 ]; then
-    TSET_STATUS="${STATIC_VAR_THIS_TEST_ERRORS} ERRORS"
+    TSET_STATUS="${RED}${STATIC_VAR_THIS_TEST_ERRORS} ERRORS${NO_COLOR}"
     RETURN_VALUE=1
   fi
   echo "=============================="
-  echo "== ${TEST_NAME} ${TSET_STATUS}"
+  echo -e "== ${TEST_NAME} ${TSET_STATUS}"
   return "${RETURN_VALUE}"
 }
 
@@ -107,8 +110,10 @@ run_test() {
   if type "${TEST}" >/dev/null 2>&1; then
     ${TEST} "${@}"
   else
+    local RED='\033[0;31m'
+    local NO_COLOR='\033[0m'
     echo "=============================="
-    echo "== ${TEST} is missing."
+    echo -e "== ${TEST} is ${RED}missing${NO_COLOR}."
     STATIC_VAR_MISSING_TESTS="${STATIC_VAR_MISSING_TESTS} ${TEST}"
     handle_failure "${TEST} is missing."
   fi
@@ -116,7 +121,9 @@ run_test() {
 
 handle_failure() {
   local MESSAGE="${1}"
-  echo "ERROR ${MESSAGE}" >&2
+  local RED='\033[0;31m'
+  local NO_COLOR='\033[0m'
+  echo -e "${RED}ERROR${NO_COLOR} ${MESSAGE}" >&2
   STATIC_VAR_THIS_TEST_ERRORS=$((STATIC_VAR_THIS_TEST_ERRORS+1))
   STATIC_VAR_ALL_ERRORS=$((STATIC_VAR_ALL_ERRORS+1))
 }
@@ -124,21 +131,25 @@ handle_failure() {
 expect_message() {
   TEXT=${1}
   MESSAGE=${2}
+  local GREEN='\033[0;32m'
+  local NO_COLOR='\033[0m'
   if ! ACTUAL_MSG=$(echo "${TEXT}" | grep -P "${MESSAGE}"); then
     handle_failure "Failed to find expected message \"${MESSAGE}\"."
     return 1
   fi
-  echo "EXPECTED found message: ${ACTUAL_MSG}"
+  echo -e "${GREEN}EXPECTED${NO_COLOR} found message: ${ACTUAL_MSG}"
 }
 
 expect_no_message() {
   TEXT=${1}
   MESSAGE=${2}
+  local GREEN='\033[0;32m'
+  local NO_COLOR='\033[0m'
   if ACTUAL_MSG=$(echo "${TEXT}" | grep -P "${MESSAGE}"); then
     handle_failure "Message \"${ACTUAL_MSG}\" should not present."
     return 1
   fi
-  echo "EXPECTED found no message matches: ${MESSAGE}"
+  echo -e "${GREEN}EXPECTED${NO_COLOR} found no message matches: ${MESSAGE}"
 }
 
 unique_id() {

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -101,8 +101,10 @@ main() {
     test_rollback_ROLLBACK_ON_FAILURE_false \
     test_options_LOG_LEVEL_none \
     test_options_UPDATE_OPTIONS \
-    test_options_CLEANUP_IMAGES_false \
     test_options_PRE_POST_RUN_CMD \
+    test_CLEANUP_IMAGES_false \
+    test_CLEANUP_IMAGES_OPTIONS_bad \
+    test_CLEANUP_IMAGES_OPTIONS_good \
   "
   local LOGIN_TESTS="\
     test_login_config \

--- a/tests/test_entrypoint.sh
+++ b/tests/test_entrypoint.sh
@@ -659,15 +659,21 @@ test_rollback_due_to_timeout() {
   local IMAGE_WITH_TAG="${1}"
   local SERVICE_NAME STDOUT
   SERVICE_NAME="gantry-test-$(unique_id)"
+  local LABEL="gantry.test"
 
   initialize_test "${FUNCNAME[0]}"
   build_and_push_test_image "${IMAGE_WITH_TAG}"
   start_replicated_service "${SERVICE_NAME}" "${IMAGE_WITH_TAG}"
   build_and_push_test_image "${IMAGE_WITH_TAG}"
+  # Prune the local copy to force re-download the image.
+  prune_local_test_image "${IMAGE_WITH_TAG}"
+  docker system prune -f;
 
   export GANTRY_SERVICES_FILTERS="name=${SERVICE_NAME}"
   # Assume service update won't be done within 1 second.
   export GANTRY_UPDATE_TIMEOUT_SECONDS=1
+  # Add a label to increase the updating time.
+  export GANTRY_UPDATE_OPTIONS="--label-add=${LABEL}=${SERVICE_NAME}"
   STDOUT=$(run_gantry "${FUNCNAME[0]}" 2>&1 | tee >(cat 1>&2))
 
   expect_no_message "${STDOUT}" "${SKIP_UPDATING_SERVICE}.*${SERVICE_NAME}"
@@ -695,15 +701,21 @@ test_rollback_failed() {
   local IMAGE_WITH_TAG="${1}"
   local SERVICE_NAME STDOUT
   SERVICE_NAME="gantry-test-$(unique_id)"
+  local LABEL="gantry.test"
 
   initialize_test "${FUNCNAME[0]}"
   build_and_push_test_image "${IMAGE_WITH_TAG}"
   start_replicated_service "${SERVICE_NAME}" "${IMAGE_WITH_TAG}"
   build_and_push_test_image "${IMAGE_WITH_TAG}"
+  # Prune the local copy to force re-download the image.
+  prune_local_test_image "${IMAGE_WITH_TAG}"
+  docker system prune -f;
 
   export GANTRY_SERVICES_FILTERS="name=${SERVICE_NAME}"
   # Assume service update won't be done within 1 second.
   export GANTRY_UPDATE_TIMEOUT_SECONDS=1
+  export GANTRY_UPDATE_OPTIONS="--label-add=${LABEL}=${SERVICE_NAME}"
+  # Rollback would fail due to the incorrect option.
   export GANTRY_ROLLBACK_OPTIONS="--incorrect_option"
   STDOUT=$(run_gantry "${FUNCNAME[0]}" 2>&1 | tee >(cat 1>&2))
 
@@ -732,15 +744,20 @@ test_rollback_ROLLBACK_ON_FAILURE_false() {
   local IMAGE_WITH_TAG="${1}"
   local SERVICE_NAME STDOUT
   SERVICE_NAME="gantry-test-$(unique_id)"
+  local LABEL="gantry.test"
 
   initialize_test "${FUNCNAME[0]}"
   build_and_push_test_image "${IMAGE_WITH_TAG}"
   start_replicated_service "${SERVICE_NAME}" "${IMAGE_WITH_TAG}"
   build_and_push_test_image "${IMAGE_WITH_TAG}"
+  # Prune the local copy to force re-download the image.
+  prune_local_test_image "${IMAGE_WITH_TAG}"
+  docker system prune -f;
 
   export GANTRY_SERVICES_FILTERS="name=${SERVICE_NAME}"
   # Assume service update won't be done within 1 second.
   export GANTRY_UPDATE_TIMEOUT_SECONDS=1
+  export GANTRY_UPDATE_OPTIONS="--label-add=${LABEL}=${SERVICE_NAME}"
   export GANTRY_ROLLBACK_ON_FAILURE="false"
   STDOUT=$(run_gantry "${FUNCNAME[0]}" 2>&1 | tee >(cat 1>&2))
 


### PR DESCRIPTION
1. Use the same image of gantry for images removal;
2. Enable adding options to the image remover global job. You can use this to add a label to the service or the containers;
3. Add color to logs and improve logging;
4. Report type success/failure to apprise;
5. Add service to the failure list when inspecting image failed;
6. Fix flaky tests;