### PR TITLE
Fix Apprise type parameter

### DIFF
--- a/src/notification.sh
+++ b/src/notification.sh
@@ -38,7 +38,7 @@ _notify_via_apprise() {
   TITLE=$(_replace_newline "${TITLE}")
   BODY=$(_replace_newline "${BODY}")
   local LOG=
-  if LOG=$(curl --silent --show-error -X POST -H "Content-Type: application/json" --data "{\"title\": \"${TITLE}\", \"body\": \"${BODY}\", \"type\": \"${TYPE}\"}" "${URL}" 2>&1); then
+  if LOG=$(curl --silent --show-error -X POST -H "Content-Type: application/json" --data "{\"title\": \"${TITLE}\", \"body\": \"${BODY}\", \"notify_type\": \"${TYPE}\"}" "${URL}" 2>&1); then
     log INFO "Sent notification via Apprise:"
     echo "${LOG}" | log_lines INFO
   else


### PR DESCRIPTION
This PR fixes the Apprise parameter for the notification type (succcess/failure/...).

See https://github.com/caronc/apprise/wiki/Development_API#message-types-and-themes and https://github.com/djmaze/apprise-microservice/pull/8